### PR TITLE
Fix ArrayIndexOutOfBoundsException and 'not connected to gaia' Error

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/blockstack-sdk/src/main/java/com/colendi/ecies/Encryption.java
+++ b/blockstack-sdk/src/main/java/com/colendi/ecies/Encryption.java
@@ -196,7 +196,11 @@ public class Encryption {
 
     public static MacAesPair sharedSecretToKeys(MessageDigest mda, byte[] derivedKeyInBytes) {
         byte[] digestKey = new byte[32];
-        System.arraycopy(derivedKeyInBytes, 0, digestKey, 0, 32);
+        if (derivedKeyInBytes.length < 32) {
+            System.arraycopy(derivedKeyInBytes, 0, digestKey, 32 - derivedKeyInBytes.length, derivedKeyInBytes.length);
+        } else {
+            System.arraycopy(derivedKeyInBytes, 0, digestKey, 0, 32);
+        }
 
         byte[] digested = mda.digest(digestKey);
 

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import com.colendi.ecies.EncryptedResultForm
 import com.colendi.ecies.Encryption
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.uport.sdk.core.hexToByteArray
 import okhttp3.Call
@@ -45,6 +47,15 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
     init {
         val appPrivateKey = sessionStore.sessionData.json.optJSONObject("userData")?.optString("appPrivateKey")
         this.appPrivateKey = appPrivateKey
+
+        CoroutineScope(dispatcher).launch {
+            try {
+                Log.d(TAG, "Call setLocalGaiaHubConnection in init")
+                setLocalGaiaHubConnection()
+            } catch (e: Exception) {
+                Log.d(TAG, "Call setLocalGaiaHubConnection in init error")
+            }
+        }
     }
 
 
@@ -507,10 +518,8 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
         }
 
         Log.d(TAG, "listFilesLoop count: ${callCount}")
-        val config = getOrSetLocalGaiaHubConnection()
-        Log.d(TAG, "listFilesLoop config: ${config}")
-        val request = buildListFilesRequest(page, config)
         val response = withContext(dispatcher) {
+            val request = buildListFilesRequest(page, getOrSetLocalGaiaHubConnection())
             callFactory.newCall(request).execute()
         }
         if (!response.isSuccessful) {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -513,8 +513,8 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
         }
         if (!response.isSuccessful) {
             if (callCount == 0) {
-                // TODO reconnect
-                throw NotImplementedError("reconnect to gaia ${response.code}")
+                // Try again one more time
+                return listFilesLoop(gaiaHubConfig, callback, page, callCount + 1, fileCount)
             } else {
                 throw IOException("call to list-files failed ${response.code}")
             }

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -232,7 +232,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
             @Suppress("NAME_SHADOWING") var path = path
             var file: File? = null
             if (path.startsWith(FILE_PREFIX)) {
-                val pathUri = Uri.parse(path.replace(FILE_PREFIX, options.dir))
+                val pathUri = Uri.parse(path.replace(FILE_PREFIX, options.dir + "/"))
                 file = File(pathUri.path!!)
                 if (file.exists()) return@withContext Result("")
 
@@ -358,7 +358,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
         @Suppress("NAME_SHADOWING") var path = path
         @Suppress("NAME_SHADOWING") var content = content
         if (path.startsWith(FILE_PREFIX)) {
-            val pathUri = Uri.parse(path.replace(FILE_PREFIX, options.dir))
+            val pathUri = Uri.parse(path.replace(FILE_PREFIX, options.dir + "/"))
             val file = File(pathUri.path!!)
             if (!file.exists()) return@withContext Result("file-does-not-exist/do-nothing-just-return")
 

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -516,7 +516,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
                 // Try again one more time
                 return listFilesLoop(gaiaHubConfig, callback, page, callCount + 1, fileCount)
             } else {
-                Log.d(TAG, "call to list-files failed ${response.code}: ${response.message}")
+                Log.d(TAG, "call to list-files failed ${response.code}: ${response.body?.string()}")
                 throw IOException("call to list-files failed ${response.code}")
             }
         } else {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -506,7 +506,10 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
             throw RuntimeException("Too many entries to list")
         }
 
-        val request = buildListFilesRequest(page, getOrSetLocalGaiaHubConnection())
+        Log.d(TAG, "listFilesLoop count: ${callCount}")
+        val config = getOrSetLocalGaiaHubConnection()
+        Log.d(TAG, "listFilesLoop config: ${config}")
+        val request = buildListFilesRequest(page, config)
         val response = withContext(dispatcher) {
             callFactory.newCall(request).execute()
         }

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -470,7 +470,6 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
      * @return {Promise} that resolves to the number of files listed
      */
     suspend fun listFiles(callback: (Result<String>) -> Boolean): Result<Int> {
-        Log.d(TAG, "BlockstackSession listFiles called")
         try {
             val fileCount = listFilesLoop(callback, null, 0, 0)
             return Result(fileCount)
@@ -507,7 +506,6 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
             throw RuntimeException("Too many entries to list")
         }
 
-        Log.d(TAG, "listFilesLoop count: ${callCount}")
         val response = withContext(dispatcher) {
             val request = buildListFilesRequest(page, getOrSetLocalGaiaHubConnection())
             callFactory.newCall(request).execute()

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -516,6 +516,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
                 // Try again one more time
                 return listFilesLoop(gaiaHubConfig, callback, page, callCount + 1, fileCount)
             } else {
+                Log.d(TAG, "call to list-files failed ${response.code}: ${response.message}")
                 throw IOException("call to list-files failed ${response.code}")
             }
         } else {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -11,7 +11,6 @@ import okhttp3.Call
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
@@ -516,7 +515,8 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
                 // Try again one more time
                 return listFilesLoop(gaiaHubConfig, callback, page, callCount + 1, fileCount)
             } else {
-                Log.d(TAG, "call to list-files failed ${response.code}: ${response.body?.string()}")
+                Log.d(TAG, "Gaia's list-files failed ${response.code}")
+                Log.d(TAG, response.body!!.string())
                 throw IOException("call to list-files failed ${response.code}")
             }
         } else {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -578,6 +578,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
     fun signUserOut() {
         sessionStore.deleteSessionData()
         appPrivateKey = null
+        gaiaHubConfig = null
     }
 
     fun validateProofs(profile: Profile, ownerAddress: String, optString: String?): Result<ArrayList<Proof>> {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -4,9 +4,7 @@ import android.util.Log
 import com.colendi.ecies.EncryptedResultForm
 import com.colendi.ecies.Encryption
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.uport.sdk.core.hexToByteArray
 import okhttp3.Call
@@ -47,15 +45,6 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
     init {
         val appPrivateKey = sessionStore.sessionData.json.optJSONObject("userData")?.optString("appPrivateKey")
         this.appPrivateKey = appPrivateKey
-
-        CoroutineScope(dispatcher).launch {
-            try {
-                Log.d(TAG, "Call setLocalGaiaHubConnection in init")
-                setLocalGaiaHubConnection()
-            } catch (e: Exception) {
-                Log.d(TAG, "Call setLocalGaiaHubConnection in init error")
-            }
-        }
     }
 
 
@@ -481,6 +470,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
      * @return {Promise} that resolves to the number of files listed
      */
     suspend fun listFiles(callback: (Result<String>) -> Boolean): Result<Int> {
+        Log.d(TAG, "BlockstackSession listFiles called")
         try {
             val fileCount = listFilesLoop(callback, null, 0, 0)
             return Result(fileCount)

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -132,6 +132,11 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
         return userData
     }
 
+    suspend fun updateUserData(userData: UserData): Result<out Unit> = withContext(dispatcher) {
+        this@BlockstackSession.appPrivateKey = userData.appPrivateKey
+        sessionStore.updateUserData(userData)
+        return@withContext Result(Unit)
+    }
 
     private suspend fun extractProfile(tokenPayload: JSONObject, nameLookupUrl: String): JSONObject {
         val profileUrl = tokenPayload.optStringOrNull("profile_url")

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/ecies/Signature.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/ecies/Signature.kt
@@ -32,6 +32,19 @@ import kotlin.math.log10
 internal val CURVE by lazy { CustomNamedCurves.getByName("secp256k1")!! }
 internal val DOMAIN_PARAMS = CURVE.run { ECDomainParameters(curve, g, n, h) }
 
+// github.com/paulmillr/noble-secp256k1/blob/97aa518b9c12563544ea87eba471b32ecf179916/index.ts
+fun signECDSA(content: Any, privateKey: String): SignatureObject {
+    val contentBuffer = if (content is ByteArray) {
+        content
+    } else {
+        (content as String).toByteArray()
+    }
+    val keyPair = PrivateKey(HexString(privateKey)).toECKeyPair()
+    val sigData = signMessageHash(contentBuffer.sha256(), keyPair, true)
+
+    val signatureString = sigData.toDER()
+    return SignatureObject(signatureString, keyPair.toHexPublicKey64())
+}
 
 fun signContent(content: Any, privateKey: String): SignatureObject {
     val contentBuffer = if (content is ByteArray) {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/ecies/Signature.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/ecies/Signature.kt
@@ -32,34 +32,18 @@ import kotlin.math.log10
 internal val CURVE by lazy { CustomNamedCurves.getByName("secp256k1")!! }
 internal val DOMAIN_PARAMS = CURVE.run { ECDomainParameters(curve, g, n, h) }
 
-// github.com/paulmillr/noble-secp256k1/blob/97aa518b9c12563544ea87eba471b32ecf179916/index.ts
-fun signECDSA(content: Any, privateKey: String): SignatureObject {
+
+fun signContent(content: Any, privateKey: String, toCanonical: Boolean = false): SignatureObject {
     val contentBuffer = if (content is ByteArray) {
         content
     } else {
         (content as String).toByteArray()
     }
     val keyPair = PrivateKey(HexString(privateKey)).toECKeyPair()
-    val sigData = signMessageHash(contentBuffer.sha256(), keyPair, true)
+    val sigData = signMessageHash(contentBuffer.sha256(), keyPair, toCanonical)
 
     val signatureString = sigData.toDER()
     return SignatureObject(signatureString, keyPair.toHexPublicKey64())
-}
-
-fun signContent(content: Any, privateKey: String): SignatureObject {
-    val contentBuffer = if (content is ByteArray) {
-        content
-    } else {
-        (content as String).toByteArray()
-    }
-    val keyPair = PrivateKey(HexString(privateKey)).toECKeyPair()
-    val sigData = signMessageHash(contentBuffer.sha256(), keyPair, false)
-
-    val signatureString = sigData.toDER()
-
-    return SignatureObject(signatureString,
-            keyPair.toHexPublicKey64()
-    )
 }
 
 fun signEncryptedContent(content: String, privateKey: String): SignedCipherObject {

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/GaiaHubConfig.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/GaiaHubConfig.kt
@@ -1,3 +1,15 @@
 package org.blockstack.android.sdk.model
 
-data class GaiaHubConfig(val urlPrefix: String, val address: String, val token: String, val server: String)
+import org.json.JSONObject
+
+data class GaiaHubConfig(val urlPrefix: String, val address: String, val token: String, val server: String) {
+
+    fun toJSON(): JSONObject {
+        val optionsObject = JSONObject()
+        optionsObject.put("url_prefix", urlPrefix)
+        optionsObject.put("address", address)
+        optionsObject.put("token", token)
+        optionsObject.put("server", server)
+        return optionsObject
+    }
+}

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/GetFileOptions.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/GetFileOptions.kt
@@ -18,7 +18,8 @@ public class GetFileOptions(val decrypt: Boolean = true,
                             val verify: Boolean = false,
                             val username: String? = null,
                             val app: String? = null,
-                            val zoneFileLookupURL: URL? = null) {
+                            val zoneFileLookupURL: URL? = null,
+                            val dir: String = "") {
 
     /**
      * json representation of these options as used by blockstack.js

--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/PutFileOptions.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/model/PutFileOptions.kt
@@ -15,7 +15,8 @@ import java.security.InvalidParameterException
  * true when retrieving the data.
  */
 public class PutFileOptions(val encrypt: Boolean = true, val encryptionKey:String? = null,
-                            val contentType: String? = null, val sign: Any = false) {
+                            val contentType: String? = null, val sign: Any = false,
+                            val dir: String = "") {
 
     /**
      * json representation of these options as used by blockstack.js

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -33,7 +33,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.blockstack.android.sdk.*
 import org.blockstack.android.sdk.model.*
-import org.blockstack.android.sdk.ecies.signECDSA
+import org.blockstack.android.sdk.ecies.signContent
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.URI
@@ -347,7 +347,7 @@ class MainActivity : AppCompatActivity() {
 
         signECDSAButton.setOnClickListener {
             val appPrivateKey = ""
-            val obj = signECDSA("Privacy Security UX", appPrivateKey)
+            val obj = signContent("Privacy Security UX", appPrivateKey, true)
             Log.d(TAG, "Public key: ${obj.publicKey}, Signature: ${obj.signature}")
             signECDSAText.text = "Public key: ${obj.publicKey}, Signature: ${obj.signature}"
         }

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -287,7 +287,7 @@ class MainActivity : AppCompatActivity() {
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
             val bitMapData = stream.toByteArray()
 
-            val fpath = this.filesDir.absolutePath + imageFileName
+            val fpath = this.filesDir.absolutePath + "/" + imageFileName
             Log.d(TAG, "Local file path: $fpath")
             val pathUri = Uri.parse(fpath)
             val file = File(pathUri.path!!)
@@ -307,7 +307,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         getLocalFileButton.setOnClickListener {
-            val fpath = this.filesDir.absolutePath + imageFileName
+            val fpath = this.filesDir.absolutePath + "/" + imageFileName
             val pathUri = Uri.parse(fpath)
             val file = File(pathUri.path!!)
             if (file.exists()) file.deleteRecursively()

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.blockstack.android.sdk.*
 import org.blockstack.android.sdk.model.*
+import org.blockstack.android.sdk.ecies.signECDSA
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.URI
@@ -342,6 +343,13 @@ class MainActivity : AppCompatActivity() {
                     it.error?.message
                 }
             }
+        }
+
+        signECDSAButton.setOnClickListener {
+            val appPrivateKey = ""
+            val obj = signECDSA("Privacy Security UX", appPrivateKey)
+            Log.d(TAG, "Public key: ${obj.publicKey}, Signature: ${obj.signature}")
+            signECDSAText.text = "Public key: ${obj.publicKey}, Signature: ${obj.signature}"
         }
 
         if (intent?.action == Intent.ACTION_VIEW) {

--- a/example/src/main/res/layout/content_main.xml
+++ b/example/src/main/res/layout/content_main.xml
@@ -150,13 +150,22 @@
         tools:ignore="ContentDescription" />
 
     <Button
+        android:id="@+id/deleteImageFileButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Delete Image File"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/imageView" />
+
+    <Button
         android:id="@+id/getStringFileFromUserButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Get String File from other user"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/imageView" />
+        app:layout_constraintTop_toBottomOf="@id/deleteImageFileButton" />
 
     <TextView
         android:id="@+id/fileFromUserContentsTextView"
@@ -218,13 +227,31 @@
         app:layout_constraintTop_toBottomOf="@id/listFilesButton" />
 
     <Button
+        android:id="@+id/putLocalFileButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Put local file"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/listFilesText" />
+
+    <Button
+        android:id="@+id/getLocalFileButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Get local file"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/putLocalFileButton" />
+
+    <Button
         android:id="@+id/getNameInfoButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Get name info of dev_android_sdk"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/listFilesText" />
+        app:layout_constraintTop_toBottomOf="@id/getLocalFileButton" />
 
     <TextView
         android:id="@+id/getNameInfoText"

--- a/example/src/main/res/layout/content_main.xml
+++ b/example/src/main/res/layout/content_main.xml
@@ -261,4 +261,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/getNameInfoButton" />
 
+    <Button
+        android:id="@+id/signECDSAButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Sign ECDSA"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/getNameInfoText" />
+
+    <TextView
+        android:id="@+id/signECDSAText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/signECDSAButton" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description

This pull request fixes 2 issues.

1. ArrayIndexOutOfBoundsException from com.colendi.ecies.Encryption:199.
```
2021-02-03 16:09:45.356 18014-18084/com.bracedotto D/BlockstackSession: getFile: path: links/My List/1607409583257-USoa-iRXm.json options: {"decrypt":true,"verify":false,"username":null,"app":null,"zoneFileLookupURL":null}
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err: java.lang.ArrayIndexOutOfBoundsException: src.length=31 srcPos=0 dst.length=32 dstPos=0 length=32
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at java.lang.System.arraycopy(Native Method)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at com.colendi.ecies.Encryption.sharedSecretToKeys(Encryption.java:199)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at com.colendi.ecies.Encryption.getMacKeyAndAesKey(Encryption.java:194)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at com.colendi.ecies.Encryption.decrypt(Encryption.java:159)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at com.colendi.ecies.Encryption.decryptWithPrivateKey(Encryption.java:62)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at com.colendi.ecies.Encryption.decryptWithPrivateKey(Encryption.java:58)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at org.blockstack.android.sdk.BlockstackSession$getFile$2.invokeSuspend(BlockstackSession.kt:263)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at org.blockstack.android.sdk.BlockstackSession$getFile$2.invoke(Unknown Source:10)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at org.blockstack.android.sdk.BlockstackSession.getFile(BlockstackSession.kt:232)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at org.blockstack.reactnative.RNBlockstackSdkModule$getFile$1.invokeSuspend(RNBlockstackSdkModule.kt:240)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2021-02-03 16:09:45.402 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2021-02-03 16:09:45.403 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
2021-02-03 16:09:45.403 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
2021-02-03 16:09:45.403 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
2021-02-03 16:09:45.403 18014-18084/com.bracedotto W/System.err:     at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Number of bytes from BigIntegers can be less than or more than 32. In case of less than 32, there will be an error. So I've added a check and if it's less than 32, the array is copied to the right of the destination array. I got it from [Colendi-ECIES](https://github.com/colendi-project/Colendi-ECIES/blob/d1c67f3f7abed00e94c53c84a80ae31e0ac8632d/src/main/java/com/colendi/ecies/Encryption.java#L186).

2. 'not connected to gaia' Error because gaiaHubConfig is null.

This can happen when listFiles or deleteFile is called before getFile or putFile as gaiaHubConfig will be initialized in these two methods only. I think, it shouldn't be the case i.e. an app can call listFiles first at the start. So I've made a change with the idea that gaiaHubConfig is lazily initialized and there are 4 methods (getFile, putFile, deleteFile, and listFiles) that can initialize gaiaHubConfig if it hasn't yet. Also, I've set it to null when user signs out.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

I just tested on my app and the examples. All of them work.
